### PR TITLE
Preprocessor additions for compiling with msvc on windows.

### DIFF
--- a/dcraw.c
+++ b/dcraw.c
@@ -48,7 +48,11 @@
 #include <time.h>
 #include <sys/types.h>
 
-#if defined(DJGPP) || defined(__MINGW32__)
+#if defined(_MSC_VER) && !defined(WIN32)
+#define WIN32
+#endif
+
+#if defined(DJGPP) || defined(__MINGW32__) || defined(_MSC_VER)
 #define fseeko fseek
 #define ftello ftell
 #else


### PR DESCRIPTION
This pull request contains the minimum localized preprocessor changes to allow building dcrawps with msvc on windows.

On windows, it can be useful to compile with both mingw-w64 and msvc as sometimes they each report issues that the other does not.

Mingw-w64 defines more WIN32-like symbols than msvc:
* Mingw-w64 32-bit/64-bit:
    * `__WIN32` 
    * `__WIN32__`
    * `_WIN32`
    * `WIN32`
* MSVC 32-bit/64-bit:
    * `_WIN32`

Note: unlike gcc, I am unfamiliar with a way to dump the pre-defined macros for msvc.  The msvc symbol above was taken from the online documentation.

Depending on which compilers are supported on windows, there may be minor opportunities to revise some of the existing preprocessor tests.

dcrawps command-line build tests on windows for this PR:
* 32-bit/64-bit builds:
    * mingw-w64 gcc 11.1 runtime v9.0
    * mingw-w64 gcc 10.3 runtime v9.0
    * mingw-w64 gcc 9.4 runtime v9.0
    * mingw-w64 gcc 8.5 runtime v9.0
    * MSVS 2019
    * MSVS 2017
    * MSVS 2015
    * MSVS 2013
    * MSVS 2012
    * MSVS 2010
    * MSVS 2008
    * MSVS 2005
* 64-bit builds:
    * cygwin gcc 10.2